### PR TITLE
WIP completely overhaul access validation. untested

### DIFF
--- a/client/control/form.js
+++ b/client/control/form.js
@@ -8,12 +8,15 @@ export const getInputValue = el =>
 			range: 'valueAsNumber',
 			date: 'valueAsDate',
 			checkbox: 'checked',
+			radio: 'value',
 		}[el.type] || 'value'
 	];
 
 export const getSelectValue = el => el.options[el.selectedIndex].value;
 
-export const FormFieldData = ({render}, context) => render(context.fields);
+export const FormFieldData = ({render}, context) => render(context.fields, context.setFields);
+
+const qq = (a, b) => a === undefined ? b : a;
 
 export const Input = (
 	{name, fieldRef, tag: Tag = 'input', ...props},
@@ -26,25 +29,19 @@ export const Input = (
 		{...props}
 		value={
 			context.fields
-				? (name in context.fields ? context.fields[name] : props.value) || ''
+				? qq(name in context.fields ? context.fields[name] : props.value, '')
 				: 'value' in props ? props.value : undefined /* uncontrolled component if there's no context */}
 		onChange={ev => {
-			if(props.onChange) {
-				props.onChange(ev);
-			}
-
 			if(context.setFields) {
-				if(props.type === 'radio') {
-					if(ev.target.checked) {
-						context.setFields({
-							[name]: props.value,
-						});
-					}
-				} else {
+				if(props.type !== 'radio' || ev.target.checked) {
 					context.setFields({
 						[name]: getInputValue(ev.target),
 					});
 				}
+			}
+
+			if(props.onChange) {
+				props.onChange(ev);
 			}
 		}}
 	/>;

--- a/client/control/privacy.js
+++ b/client/control/privacy.js
@@ -1,0 +1,69 @@
+import React from 'react';
+import {Form, FormFieldData, Select, Input, getInputValue} from './form';
+import accessLevels from '../../shared/access';
+import Icon from '../visual/icon';
+import {LabelledInput as Label, FormGroup} from '../visual/primitives';
+import styled from 'styled-components';
+
+const match = matches => value => value in matches ? matches[value] : matches.default;
+
+const getPrivacyIcon = match({
+	[accessLevels.PRIVATE]:  'lock',
+	[accessLevels.AND_GM]:   'handshake-o',
+	[accessLevels.CAMPAIGN]: 'double-team',
+	[accessLevels.PUBLIC]:   'globe',
+});
+
+const getPrivacyLabel = match({
+	[accessLevels.PRIVATE]:  'Only You',
+	[accessLevels.AND_GM]:   'You and the GM',
+	[accessLevels.CAMPAIGN]: 'Campaign',
+	[accessLevels.PUBLIC]:   'Public',
+});
+
+const defaultAccess = {view: accessLevels.PRIVATE, edit: accessLevels.PRIVATE};
+
+const PrivacyIcon = ({level}) => <Icon icon={getPrivacyIcon(level)} />;
+
+export const PrivacyIcons = ({access = defaultAccess}) => <>
+	<span>view <PrivacyIcon level={access.view} /></span>
+	<span>edit <PrivacyIcon level={access.edit} /></span>
+</>;
+
+const Range = styled(Input)`
+	width: ${({max}) => 100 * max / accessLevels.PUBLIC}px;
+`
+
+const AccessSelect = ({maxLevel = accessLevels.PUBLIC, ...props}) => <Range
+	{...props}
+	type='range'
+	min={accessLevels.PRIVATE}
+	max={maxLevel}
+	step={1}
+	disabled={maxLevel === accessLevels.PRIVATE}
+/>;
+
+const AccessForm = ({ access = defaultAccess }) => (
+	<Form tag={FormGroup} initialData={access} name='access'>
+		<FormFieldData render={({view, edit}, setFields) => <>
+			<Label>
+				Visible to
+				<AccessSelect name='view' onChange={ev => {
+					setFields({
+						edit: Math.min(getInputValue(ev.target), edit)
+					})
+				}} />
+				<PrivacyIcon level={view} />
+				{getPrivacyLabel(view)}
+			</Label>
+			<Label>
+				Editable by
+				<AccessSelect name='edit' maxLevel={view} />
+				<PrivacyIcon level={edit} />
+				{getPrivacyLabel(edit)}
+			</Label>
+		</>} />
+	</Form>
+);
+
+export default AccessForm;

--- a/client/control/privacy.js
+++ b/client/control/privacy.js
@@ -9,14 +9,12 @@ const match = matches => value => value in matches ? matches[value] : matches.de
 
 const getPrivacyIcon = match({
 	[accessLevels.PRIVATE]:  'lock',
-	[accessLevels.AND_GM]:   'handshake-o',
 	[accessLevels.CAMPAIGN]: 'double-team',
 	[accessLevels.PUBLIC]:   'globe',
 });
 
 const getPrivacyLabel = match({
 	[accessLevels.PRIVATE]:  'Only You',
-	[accessLevels.AND_GM]:   'You and the GM',
 	[accessLevels.CAMPAIGN]: 'Campaign',
 	[accessLevels.PUBLIC]:   'Public',
 });

--- a/client/document/card.js
+++ b/client/document/card.js
@@ -29,6 +29,7 @@ import {Input, Textarea} from '../visual/form';
 import CardSelect from '../collection/card-select';
 import Icon from '../visual/icon';
 import AccessForm, {PrivacyIcons} from '../control/privacy';
+import {iAmOwner} from '../data/owner';
 
 const SchemaFields = (props, context) => context.fields.type ? <FormGroup>
 	{_.map(
@@ -42,7 +43,7 @@ const SchemaFields = (props, context) => context.fields.type ? <FormGroup>
 
 SchemaFields.contextTypes = fieldLike;
 
-export const EditCard = ({card, saveCard, toggle, deleteCard}) =>
+export const EditCard = ({card, saveCard, toggle, deleteCard, isOwner}) =>
 	<Form
 		onSubmit={saveCard}
 		onDidSubmit={toggle}
@@ -55,7 +56,7 @@ export const EditCard = ({card, saveCard, toggle, deleteCard}) =>
 			</List>
 		</FormGroup>
 
-		<AccessForm {...card} />
+		{isOwner && <AccessForm {...card} />}
 
 		<FormGroup>
 			<Textarea name="text" fullWidth />
@@ -82,7 +83,7 @@ export const EditCard = ({card, saveCard, toggle, deleteCard}) =>
 		</List>
 	</Form>;
 
-const connectEditCard = withHandlers({
+const editCardActions = withHandlers({
 	saveCard: ({card}) => data => {
 		Card.update(card, data);
 	},
@@ -93,6 +94,11 @@ const connectEditCard = withHandlers({
 	},
 });
 
+const connectEditCard = compose(
+	editCardActions,
+	iAmOwner('card')
+);
+
 const EditCardContainer = connectEditCard(EditCard);
 
 const ShowCard = ({
@@ -101,7 +107,7 @@ const ShowCard = ({
 	relatedCards,
 	removeRelated,
 	addRelated,
-	userId,
+	userId
 }) =>
 	<div>
 		{card.type && <Label colour='sky'>

--- a/client/document/card.js
+++ b/client/document/card.js
@@ -11,6 +11,7 @@ import schema from '../../shared/schema';
 import preventingDefault from '../utils/preventing-default';
 import Link from '../control/link';
 import {Card, addRelated, removeRelated} from '../../shared/methods';
+import {canEdit as canEditCard} from '../../shared/utils/validators/card';
 
 import Toggler from '../control/toggler';
 import {
@@ -27,11 +28,12 @@ import {Form, fieldLike} from '../control/form';
 import {Input, Textarea} from '../visual/form';
 import CardSelect from '../collection/card-select';
 import Icon from '../visual/icon';
+import AccessForm, {PrivacyIcons} from '../control/privacy';
 
 const SchemaFields = (props, context) => context.fields.type ? <FormGroup>
 	{_.map(
 		schema[context.fields.type].fields,
-		({label, ...field}, key) => <LabelledInput key={key}>
+		({label, format, ...field}, key) => <LabelledInput key={key}>
 			<div>{label}</div>
 			<Input {...field} name={key} key={key} />
 		</LabelledInput>
@@ -52,6 +54,8 @@ export const EditCard = ({card, saveCard, toggle, deleteCard}) =>
 				<TypeSelect name="type" placeholder="Type..." />
 			</List>
 		</FormGroup>
+
+		<AccessForm {...card} />
 
 		<FormGroup>
 			<Textarea name="text" fullWidth />
@@ -97,6 +101,7 @@ const ShowCard = ({
 	relatedCards,
 	removeRelated,
 	addRelated,
+	userId,
 }) =>
 	<div>
 		{card.type && <Label colour='sky'>
@@ -106,10 +111,12 @@ const ShowCard = ({
 		</Label>}
 
 		<List>
-			{toggle && <Button onClick={toggle}>
+			{toggle && canEditCard(card, userId) && <Button onClick={toggle}>
 				<Icon icon='edit' />
 			</Button>}
 		</List>
+
+		<PrivacyIcons access={card.access} />
 
 		<article>
 			<h1>
@@ -159,6 +166,8 @@ const withCardData = withTracker(({card, campaignId, campaignSession}) => ({
 	removeRelated(related) {
 		removeRelated(card, related);
 	},
+
+	userId: Meteor.userId(),
 }));
 
 const connectCard = compose(withCampaignSession, withCardData);

--- a/server/publications.js
+++ b/server/publications.js
@@ -29,8 +29,7 @@ const visibleDocs = collection => ({userId}) => {
 /*
 i can see a card if:
 
-- i'm the owner
-- it's visible to the GM, and it's in a campaign i own
+- i'm the owner or the GM
 - it's visible to the campaign, it's in a campaign i'm a member of
 - it's public
  */
@@ -42,7 +41,7 @@ const visibleCards = ({userId}) => {
 	return Cards.find({
 		$or: [
 			{owner: userId},
-			{campaignId: {$in: ownedCampaignIds}, 'access.view': access.AND_GM},
+			{campaignId: {$in: ownedCampaignIds}},
 			{campaignId: {$in: memberCampaignIds}, 'access.view': access.CAMPAIGN},
 			{'access.view': access.PUBLIC},
 		]

--- a/server/publications.js
+++ b/server/publications.js
@@ -42,9 +42,9 @@ const visibleCards = ({userId}) => {
 	return Cards.find({
 		$or: [
 			{owner: userId},
-			{campaignId: {$in: ownedCampaignIds}, access: {view: access.AND_GM}},
-			{campaignId: {$in: memberCampaignIds}, access: {view: access.CAMPAIGN}},
-			{access: {view: access.PUBLIC}},
+			{campaignId: {$in: ownedCampaignIds}, 'access.view': access.AND_GM},
+			{campaignId: {$in: memberCampaignIds}, 'access.view': access.CAMPAIGN},
+			{'access.view': access.PUBLIC},
 		]
 	});
 };

--- a/shared/access.js
+++ b/shared/access.js
@@ -1,0 +1,6 @@
+export default {
+	PRIVATE:  0,
+	AND_GM:   1,
+	CAMPAIGN: 2,
+	PUBLIC:   3,
+};

--- a/shared/access.js
+++ b/shared/access.js
@@ -1,6 +1,5 @@
 export default {
 	PRIVATE:  0,
-	AND_GM:   1,
-	CAMPAIGN: 2,
-	PUBLIC:   3,
+	CAMPAIGN: 1,
+	PUBLIC:   2,
 };

--- a/shared/methods.js
+++ b/shared/methods.js
@@ -5,10 +5,11 @@ import method from './utils/method';
 import collectionMethods from './utils/collection-methods';
 import {Accounts} from 'meteor/accounts-base';
 import generateSlug from './utils/generate-slug';
+import * as validators from './utils/validators';
 
-export const Campaign = collectionMethods(Campaigns);
-export const Card = collectionMethods(Cards);
-export const Layout = collectionMethods(Layouts);
+export const Campaign = collectionMethods(Campaigns, validators.doc);
+export const Card = collectionMethods(Cards, validators.card);
+export const Layout = collectionMethods(Layouts, validators.campaignDoc);
 
 const serverToken = Random.secret();
 

--- a/shared/utils/collection-methods.js
+++ b/shared/utils/collection-methods.js
@@ -3,35 +3,9 @@ import {Campaigns} from '../collections';
 import generateSlug from './generate-slug';
 import {Meteor} from 'meteor/meteor';
 
-const validateAccess = (collection, data, userId, verb) => {
-	if(!userId) {
-		throw new Meteor.Error('not-logged-in', `Can't ${verb} something if you're not logged in`);
-	}
-
-	if(verb !== 'create') {
-		if(!data) {
-			throw new Meteor.Error('doc-doesnt-exist', `Can't ${verb} a document that doesn't exist`);
-		}
-
-		if(data.owner !== userId) {
-			throw new Meteor.Error('doc-access-denied', `Can't ${verb} that document`);
-		}
-	}
-
-	if(collection !== Campaigns) { // hmmm
-		if(!data.campaignId) throw new Meteor.Error('campaign-missing', 'No campaign ID in data');
-
-		const campaign = Campaigns.findOne(data.campaignId);
-		if(!campaign || (campaign.owner !== userId && !campaign.member.includes(userId))) {
-			throw new Meteor.Error('campaign-access-denied', `Can't ${verb} a document in that campaign`);
-		}
-	}
-};
-
-export default collection => {
+export default (collection, validate) => {
 	const baseCreate = method(`${collection._name}.create`, function(data) {
-		// TODO validate data against card schema
-		validateAccess(collection, data, this.userId, 'create');
+		validate.create(data, this.userId);
 
 		data.owner = this.userId;
 		collection.insert(data);
@@ -46,16 +20,15 @@ export default collection => {
 		),
 
 		update: method(`${collection._name}.update`, function({_id}, $set) {
-			// TODO validate update against card schema
 			const data = collection.findOne(_id);
-			validateAccess(collection, data, this.userId, 'update');
+			validate.edit(data, this.userId);
 
 			collection.update(_id, { $set });
 		}),
 
 		delete: method(`${collection._name}.delete`, function({_id}) {
 			const data = collection.findOne(_id);
-			validateAccess(collection, data, this.userId, 'delete');
+			validate.edit(data, this.userId);
 			collection.remove(_id);
 		}),
 	};

--- a/shared/utils/collection-methods.js
+++ b/shared/utils/collection-methods.js
@@ -21,7 +21,7 @@ export default (collection, validate) => {
 
 		update: method(`${collection._name}.update`, function({_id}, $set) {
 			const data = collection.findOne(_id);
-			validate.edit(data, this.userId);
+			validate.edit(data, this.userId, $set);
 
 			collection.update(_id, { $set });
 		}),

--- a/shared/utils/validators/campaign-doc.js
+++ b/shared/utils/validators/campaign-doc.js
@@ -1,0 +1,28 @@
+import {Campaigns} from '../../collections';
+import {isLoggedIn} from './common';
+import {edit as canEditDoc} from './doc';
+
+const canAccessCampaignDoc = (data, userId, verb) => {
+	const campaign = Campaigns.findOne(data.campaignId);
+
+	if(campaign && campaign.owner === userId) {
+		return true;
+	}
+
+	if(campaign && campaign.member.includes(userId)) {
+		return true;
+	}
+
+	throw new Meteor.Error('campaign-access-denied', `Can't ${verb} a document in that campaign`);
+};
+
+export const create = (data, userId) => {
+	isLoggedIn(data, userId, 'create');
+	canAccessCampaignDoc(data, userId, 'create');
+};
+
+export const edit = (data, userId) => {
+	isLoggedIn(data, userId, 'edit');
+	canAccessCampaignDoc(data, userId, 'edit');
+	canEditDoc(data, userId);
+};

--- a/shared/utils/validators/card.js
+++ b/shared/utils/validators/card.js
@@ -58,8 +58,8 @@ export const canEdit = (data, userId, edit) => {
 	return false;
 };
 
-export const edit = (data, userId) => {
-	if(canEdit(data, userId)) {
+export const edit = (data, userId, edit) => {
+	if(canEdit(data, userId, edit)) {
 		return true;
 	}
 

--- a/shared/utils/validators/card.js
+++ b/shared/utils/validators/card.js
@@ -1,0 +1,48 @@
+import {Campaigns} from '../../collections';
+import access from '../../access';
+
+// create validation is the same as any doc that belongs to a campaign
+export {create} from './campaign-doc';
+
+/*
+i can edit a card if:
+
+- i'm the owner
+- it's editable by the GM, and i own the campaign it's in
+- it's editable by the campaign, and i'm a member of the campaign it's in
+- it's editable by the public (???)
+ */
+export const edit = (data, userId) => {
+	const campaign = Campaigns.findOne(data.campaignId);
+
+	if(!data.access) {
+		// fallback for unmigrated cards, treat them as private
+		if(data.owner === userId) {
+			return true;
+		}
+	} else {
+		if(data.access.edit >= access.PRIVATE) {
+			if(data.owner === userId) {
+				return true;
+			}
+		}
+
+		if(data.access.edit >= access.AND_GM) {
+			if(campaign && campaign.owner === userId) {
+				return true;
+			}
+		}
+
+		if(data.access.edit >= access.CAMPAIGN) {
+			if(campaign && campaign.member.includes(userId)) {
+				return true;
+			}
+		}
+
+		if(data.access.edit === access.PUBLIC) {
+			return true;
+		}
+	}
+
+	throw new Meteor.Error('card-access-denied', `Can't edit that card`);
+};

--- a/shared/utils/validators/card.js
+++ b/shared/utils/validators/card.js
@@ -7,8 +7,7 @@ export {create} from './campaign-doc';
 /*
 i can edit a card if:
 
-- i'm the owner
-- it's editable by the GM, and i own the campaign it's in
+- i'm the owner or the GM of the campaign
 - it's editable by the campaign, and i'm a member of the campaign it's in
 - it's editable by the public (???)
  */
@@ -36,9 +35,7 @@ export const canEdit = (data, userId, edit) => {
 			if(data.owner === userId) {
 				return true;
 			}
-		}
 
-		if(data.access.edit >= access.AND_GM) {
 			if(campaign && campaign.owner === userId) {
 				return true;
 			}

--- a/shared/utils/validators/common.js
+++ b/shared/utils/validators/common.js
@@ -1,0 +1,7 @@
+export const isLoggedIn = (data, userId, verb) => {
+	if(userId) {
+		return true;
+	}
+
+	throw new Meteor.Error('not-logged-in', `Can't ${verb} something if you're not logged in`);
+};

--- a/shared/utils/validators/doc.js
+++ b/shared/utils/validators/doc.js
@@ -1,0 +1,14 @@
+import {isLoggedIn} from './common';
+
+export const create = (data, userId) => isLoggedIn(data, userId, 'create');
+
+export const edit = (data, userId) => {
+	isLoggedIn(data, userId, 'edit');
+
+	if(data.owner === userId) {
+		return true;
+	}
+
+	// shrink and transform into a corn cob
+	throw new Meteor.Error('doc-access-denied', `Can't edit that document`);
+};

--- a/shared/utils/validators/index.js
+++ b/shared/utils/validators/index.js
@@ -1,0 +1,5 @@
+import * as doc from './doc';
+import * as campaignDoc from './campaign-doc';
+import * as card from './card';
+
+export {doc, campaignDoc, card};


### PR DESCRIPTION
a card has four levels of access, for view and edit:

- private (visible/editable by owner & owner of campaign)
- +campaign (visible/editable by owner & members of campaign)
- public (visble/editable by anybody)

todo:

- [x] test!
- [x] surface these in the ui
- [x] ensure edit permission is always <= view permission