### PR TITLE
add support for mailtrap and use it by default for review apps, fixes #125

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,23 +1,28 @@
 {
   "name": "almanac",
-  "scripts": {
-  },
+  "scripts": {},
   "env": {
     "HEROKU_APP_NAME": {
       "required": true
     },
     "UNSPLASH_ACCESS_KEY": {
       "required": false
+    },
+    "MAILTRAP_API_TOKEN": {
+      "required": false
     }
   },
-  "formation": {
-  },
+  "formation": {},
   "addons": [
     "mongolab",
-    "mailgun:starter"
+    "mailtrap"
   ],
   "buildpacks": [
-    {"url": "https://github.com/heroku/heroku-buildpack-nodejs.git"},
-    {"url": "https://github.com/AdmitHub/meteor-buildpack-horse.git"}
+    {
+      "url": "https://github.com/heroku/heroku-buildpack-nodejs.git"
+    },
+    {
+      "url": "https://github.com/AdmitHub/meteor-buildpack-horse.git"
+    }
   ]
 }


### PR DESCRIPTION
this gets around the limitations of mailgun sandbox by not using mailgun. instead review apps use mailtrap which is a kind of fake mailbox. to use it click on the mailtrap link on the overview or resources page on the review app on heroku 
<img width="295" alt="screen shot 2019-01-22 at 19 06 15" src="https://user-images.githubusercontent.com/631757/51559066-db8efa00-1e78-11e9-9b77-2e71abd0965f.png">
<img width="1007" alt="screen shot 2019-01-22 at 19 06 59" src="https://user-images.githubusercontent.com/631757/51559097-ed709d00-1e78-11e9-8c5f-b37e60548e78.png">